### PR TITLE
fix "requirements and troubleshooting" section link (wrong casing)

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@
 
 ## TL;DR
 
-1. **READ** the [Requirements and troubleshooting](https://ericzimmerman.github.io/#!index.md#Requirements_and_troubleshooting) section!!
+1. **READ** the [Requirements and troubleshooting](https://ericzimmerman.github.io/#!index.md#requirements-and-troubleshooting) section!!
 2. Use [Get-ZimmermanTools](https://f001.backblazeb2.com/file/EricZimmermanTools/Get-ZimmermanTools.zip) to download all programs at once and keep your tool set current
     - Use **-Dest** to control where the tools ends up, else things end up in same directory as the script (recommended!)
     - Use **-NetVersion** to control which flavor of tool you get: 4 for .net 4.6.2 and 6 for .net 6 (recommended!)


### PR DESCRIPTION
Hi!

I just saw this while browsing your website of awesome tools, that there was a slightly wrong link/anchor